### PR TITLE
Add workdir instruction

### DIFF
--- a/appengine/Dockerfile
+++ b/appengine/Dockerfile
@@ -5,4 +5,5 @@ ONBUILD RUN /app/build.sh
 
 EXPOSE 8080
 CMD []
+WORKDIR /app
 ENTRYPOINT ["/app/_ah_exe"]


### PR DESCRIPTION
This make sure the app binary is invoked at the root of the app's files.
