### PR TITLE
base: update Go version to 1.3

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/debian:wheezy
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl build-essential ca-certificates git mercurial bzr
-RUN mkdir /goroot && curl https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
+RUN mkdir /goroot && curl https://storage.googleapis.com/golang/go1.3.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 RUN mkdir /gopath
 
 ENV GOROOT /goroot


### PR DESCRIPTION
The current stable version is now 1.3.
