### PR TITLE
Dockerfile updated to golang 1.3.3

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,8 +1,12 @@
 FROM google/debian:wheezy
 
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl build-essential ca-certificates git mercurial bzr
-RUN mkdir /goroot && curl https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
-RUN mkdir /gopath
+ENV GOLANG_VERSION  1.3.3
+
+RUN apt-get update -y \ 
+  && apt-get install --no-install-recommends -y -q curl build-essential ca-certificates git mercurial bzr \
+  && mkdir /goroot \
+  && curl https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1 \
+  && mkdir /gopath
 
 ENV GOROOT /goroot
 ENV GOPATH /gopath


### PR DESCRIPTION
Dockerfile updated to install golang 1.3.3 and for easier updating