### PR TITLE
use 1.5beta2

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM google/debian:wheezy
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl build-essential ca-certificates git mercurial bzr
-RUN mkdir /goroot && curl https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
+RUN mkdir /goroot && curl https://storage.googleapis.com/golang/go1.5beta2.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 RUN mkdir /gopath
 
 ENV GOROOT /goroot


### PR DESCRIPTION
Hello there,

I really'd like to test docker go1.5beta2 for my builds.

I think you need to create a branch 1.5beta2, ( can't do it from here, sorry )

Cheers ! :)