### PR TITLE
golang-docker: update base image to use Go 1.5.1

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,11 +8,16 @@ RUN apt-get update \
        --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.5
+ENV GO_VERSION 1.5.1
+ENV GO_TARFILE go${GO_VERSION}.linux-amd64.tar.gz
+ENV GO_DOWNLOAD_URL https://golang.org/dl/${GO_TARFILE}
+ENV GO_DOWNLOAD_SHA1 46eecd290d8803887dec718c691cc243f2175fe0
 ENV GO_WRAPPER_COMMIT 6ea1f29b1fe7e6b0b8eb89493ed5e06bac454654
 
-RUN curl -sSL https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz \
-    | tar -v -C /usr/local -xz
+RUN curl -fsSLO "${GO_DOWNLOAD_URL}" \
+	&& echo "${GO_DOWNLOAD_SHA1} ${GO_TARFILE}" | sha1sum -c - \
+	&& tar -C /usr/local -xzf ${GO_TARFILE} \
+	&& rm ${GO_TARFILE}
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/app/_gopath

--- a/base/README.md
+++ b/base/README.md
@@ -11,7 +11,7 @@ It serves as a base for Go apps running on Google App Engine
 
 ### Vendoring
 
-Your application will be built using Go 1.5 inside the docker instance without
+Your application will be built using Go 1.5.1 inside the docker instance without
 the experimental vendoring support.  To enable Go 1.5 experimental vendoring
 support, set the environment variable like this:
 


### PR DESCRIPTION
Fixes #39.

Change-Id: I164befec3a900d625e39f760667b52eccf324e70