### PR TITLE
Use Go 1.6

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
        --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.5
-ENV GO_WRAPPER_COMMIT 6ea1f29b1fe7e6b0b8eb89493ed5e06bac454654
+ENV GO_VERSION 1.6
+ENV GO_WRAPPER_COMMIT 3cdd85183c0f3f6608588166410d24260cd8cb2f
 
 RUN curl -sSL https://golang.org/dl/go$GO_VERSION.linux-amd64.tar.gz \
     | tar -v -C /usr/local -xz
@@ -19,7 +19,7 @@ ENV GOPATH /go:/go/src/app/_gopath
 
 RUN mkdir -p /go/src/app /go/bin && chmod -R 777 /go
 
-RUN curl https://raw.githubusercontent.com/docker-library/golang/${GO_WRAPPER_COMMIT}/1.5/go-wrapper \
+RUN curl https://raw.githubusercontent.com/docker-library/golang/${GO_WRAPPER_COMMIT}/1.6/go-wrapper \
     -o /usr/local/bin/go-wrapper \
     && chmod 755 /usr/local/bin/go-wrapper
 


### PR DESCRIPTION
I successfully set up an App Engine Managed VM with [an image built with this configuration](https://hub.docker.com/r/blixt/appengine_golang/).