### PR TITLE
Switch base image from base to debian8

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile that runs a App Engine flexible environment Go application.
-FROM gcr.io/google_appengine/base
+FROM gcr.io/google_appengine/debian8
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
The newest debian images for jessie (gcr.io/google-appengine/debian8:latest) now has all the extra env variables and ca-certs that were in base.

cc @dlorenc 
