### PR TITLE
prevent container build from using cached images

### DIFF
--- a/base/cloudbuild.yaml.in
+++ b/base/cloudbuild.yaml.in
@@ -1,6 +1,6 @@
 steps:
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '--tag=${IMAGE}', './base']
+    args: ['build', '--tag=${IMAGE}', '--no-cache', './base']
     id: BUILD
   - name: gcr.io/gcp-runtimes/structure_test
     args: ['--image', '${IMAGE}', '-v', '--config', '/workspace/test/test_config.yaml']


### PR DESCRIPTION
this will ensure security updates are picked up in the cloud build.