### PR TITLE
add license tests to structure tests

### DIFF
--- a/test/test_config.yaml
+++ b/test/test_config.yaml
@@ -17,3 +17,7 @@ commandTests:
 - name: "Workdir Symlink"
   command: ['pwd', '-P']
   expectedOutput: ["/go/src/app\n"]
+
+licenseTests:
+- debian: true
+  files: []


### PR DESCRIPTION
License tests are automated tests to check that all packages installed in the image conform to Google's open source licensing stardards. Check out https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests#license-tests for more details.