### PR TITLE
Debugger degrades more gracefully.

### DIFF
--- a/base/third_party/go-wrapper/go-wrapper
+++ b/base/third_party/go-wrapper/go-wrapper
@@ -89,12 +89,13 @@ case "$cmd" in
 		if [ -f "./source-context.json" ]; then
 			service="${GAE_SERVICE:-default}"
 			version="${GAE_VERSION:-default}"
+			goBinLoc="$(which goBin)"
 			set +e; set -x; go-cloud-debug \
 				-sourcecontext ./source-context.json \
 				-appmodule "${service}" \
 				-appversion "${version}" \
-				-- "$(which $goBin)" "$@"
-			if [ "$?" -eq 3 ]; then # fallback to running the binary itself if failed to get the application default credentials.
+				-- "$goBinLoc" "$@"
+			if [ "$?" -eq 103 ]; then # fallback to running the binary itself if failed to get the application default credentials.
 				set -x; exec "$goBin" "$@"
 			fi
 		else

--- a/base/third_party/go-wrapper/go-wrapper
+++ b/base/third_party/go-wrapper/go-wrapper
@@ -1,5 +1,5 @@
 #!/bin/sh
-# set -e
+set -e
 
 usage() {
 	base="$(basename "$0")"
@@ -97,7 +97,7 @@ case "$cmd" in
 				-- "$goBinLoc" "$@"
 			exitCode="$?"
 			if [ "$exitCode" -eq 103 ]; then
-                # Fallback to running the binary itself if failed to get the application default credentials.
+				# Fallback to running the binary itself if failed to get the application default credentials.
 				exec "$goBin" "$@"
             else
                 exit "$exitCode"

--- a/base/third_party/go-wrapper/go-wrapper
+++ b/base/third_party/go-wrapper/go-wrapper
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+# set -e
 
 usage() {
 	base="$(basename "$0")"
@@ -89,14 +89,18 @@ case "$cmd" in
 		if [ -f "./source-context.json" ]; then
 			service="${GAE_SERVICE:-default}"
 			version="${GAE_VERSION:-default}"
-			goBinLoc="$(which goBin)"
+			goBinLoc="$(which $goBin)"
 			set +e; set -x; go-cloud-debug \
 				-sourcecontext ./source-context.json \
 				-appmodule "${service}" \
 				-appversion "${version}" \
 				-- "$goBinLoc" "$@"
-			if [ "$?" -eq 103 ]; then # fallback to running the binary itself if failed to get the application default credentials.
-				set -x; exec "$goBin" "$@"
+			exitCode="$?"
+			if [ "$exitCode" -eq 103 ]; then
+                # Fallback to running the binary itself if failed to get the application default credentials.
+				exec "$goBin" "$@"
+            else
+                exit "$exitCode"
 			fi
 		else
 			set -x; exec "$goBin" "$@"

--- a/base/third_party/go-wrapper/go-wrapper
+++ b/base/third_party/go-wrapper/go-wrapper
@@ -89,11 +89,14 @@ case "$cmd" in
 		if [ -f "./source-context.json" ]; then
 			service="${GAE_SERVICE:-default}"
 			version="${GAE_VERSION:-default}"
-			set -x; exec go-cloud-debug \
+			set +e; set -x; go-cloud-debug \
 				-sourcecontext ./source-context.json \
 				-appmodule "${service}" \
 				-appversion "${version}" \
 				-- "$(which $goBin)" "$@"
+			if [ "$?" -eq 3 ]; then # fallback to running the binary itself if failed to get the application default credentials.
+				set -x; exec "$goBin" "$@"
+			fi
 		else
 			set -x; exec "$goBin" "$@"
 		fi


### PR DESCRIPTION
Fallback to running the binary itself if failed to get the application
default credentials.
The corresponding change to the Cloud Debug Agent is at
https://code-review.googlesource.com/c/10431/