### PR TITLE
Fix error in the go-build script

### DIFF
--- a/runtime-builder/go-build.sh
+++ b/runtime-builder/go-build.sh
@@ -26,7 +26,7 @@ if [[ -z "${workspace}" ]]; then
     usage
 fi
 
-if [[ -z "${GO_VERSION}" -o -z "${DEBIAN_DIGEST}" ]]; then
+if [[ -z "${GO_VERSION}" || -z "${DEBIAN_DIGEST}" ]]; then
     echo "Missing env variable(s): GO_VERSION='${GO_VERSION}', DEBIAN_DIGEST='${DEBIAN_DIGEST}'."
     exit 1
 fi


### PR DESCRIPTION
Didn't know that "-o" only works with single bracket. This will cause error when deploying not building.