### PR TITLE
Fix the URL of the appengine debian image

### DIFF
--- a/runtime-builder/build.sh
+++ b/runtime-builder/build.sh
@@ -25,7 +25,7 @@ usage() { echo "Usage: $0 <project> <go_version>"; exit 1; }
 
 debian_digest()
 {
-  local digest="$(gcloud beta container images describe gcr.io/google_appengine/debian8:latest | \
+  local digest="$(gcloud beta container images describe gcr.io/google-appengine/debian8:latest | \
     grep '^Image:' | cut -d'@' -f2 | grep '^sha256:')"
 
   # The digest consists a prefix "sha256:", the hash string and a trailing newline character.

--- a/runtime-builder/go-build.sh
+++ b/runtime-builder/go-build.sh
@@ -54,7 +54,7 @@ mv "${staging}" "${workspace}"/app
 
 # Generate application Dockerfile.
 cat > Dockerfile <<EOF
-FROM gcr.io/google_appengine/debian8@${DEBIAN_DIGEST}
+FROM gcr.io/google-appengine/debian8@${DEBIAN_DIGEST}
 
 LABEL go_version="${GO_VERSION}"
 


### PR DESCRIPTION
The google_appengine project started not working, changing this to google-appengine fixes the problem.