### PR TITLE
Update build artifacts for integration tests

### DIFF
--- a/runtime-builder/tests/README.md
+++ b/runtime-builder/tests/README.md
@@ -15,7 +15,8 @@ To perform the test:
 * Manually run a container build of the go1-builder image. Skip this step if you already have an existing image in GCR that you want to test.
 * Set `gcloud config set app/use_runtime_builders true`
 * Set `gcloud config set app/runtime_builders_root` to the integration/ directory.
-* Run test.sh \<project_id>. This will use the configured test.yaml to build and deploy the test app. It will also invoke the test driver to perform the test suite to verify that it is working.
+* Run test.sh \<project_id>. This will use the generated test.yaml to build and deploy the test app. It will also invoke the test driver to perform the test suite to verify that it is working.
+* Optionally pass in the builder image tag name as the second parameter to use a different builder image (default tag is "staging").
 
 ### Caveat
 There is an issue with the authentication of the test framework.

--- a/runtime-builder/tests/README.md
+++ b/runtime-builder/tests/README.md
@@ -9,13 +9,13 @@ for information on how to write tests.
 
 ## Integration Test
 The \/integration directory contains a test web application for performing an end to end test.
-Refer to integration test framework [README](https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/integration_tests) for the design and requirements. The directory serves as a GOPATH. It also includes all the dependencies for it to be used by the test container. A go-test.yaml is provided as the cloudbuild.yaml for deploying the app and it points to the staging go1-builder image. Every newly built image will have the "staging" tag.
+Refer to integration test framework [README](https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/integration_tests) for the design and requirements. The directory serves as a GOPATH. It also includes all the dependencies for it to be used by the test container. A test.yaml.in is provided as the templated cloudbuild.yaml for deploying the app: the ${STAGING_IMAGE} environment variable will contain the path to the go1-builder staging image to use (this variable must be set). Every newly built image will have the "staging" tag.
 
 To perform the test:
 * Manually run a container build of the go1-builder image. Skip this step if you already have an existing image in GCR that you want to test.
 * Set `gcloud config set app/use_runtime_builders true`
 * Set `gcloud config set app/runtime_builders_root` to the integration/ directory.
-* Run test.sh \<project_id>. This will use the configured go-test.yaml to build and deploy the test app. It will also invoke the test driver to perform the test suite to verify that it is working.
+* Run test.sh \<project_id>. This will use the configured test.yaml to build and deploy the test app. It will also invoke the test driver to perform the test suite to verify that it is working.
 
 ### Caveat
 There is an issue with the authentication of the test framework.

--- a/runtime-builder/tests/integration/.gitignore
+++ b/runtime-builder/tests/integration/.gitignore
@@ -1,0 +1,1 @@
+test.yaml

--- a/runtime-builder/tests/integration/go-test.yaml
+++ b/runtime-builder/tests/integration/go-test.yaml
@@ -1,6 +1,9 @@
 steps:
-- name: 'gcr.io/${PROJECT_ID}/go1-builder:staging'
-- name: 'gcr.io/cloud-builders/docker:latest'
-  args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
-images:
-- '$_OUTPUT_IMAGE'
+- name: gcr.io/gcp-runtimes/integration_test
+  args: [
+    '--no-deploy',
+    '--url', 'https://$PROJECT_ID.appspot.com',
+    '--skip-monitoring-tests',
+    '--skip-standard-logging-tests',
+    '--skip-custom-logging-tests'
+  ]

--- a/runtime-builder/tests/integration/runtimes.yaml
+++ b/runtime-builder/tests/integration/runtimes.yaml
@@ -3,4 +3,4 @@ schema_version: 1
 runtimes:
   go:
     target:
-      file: go-test.yaml
+      file: test.yaml

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -34,7 +34,8 @@ if [[ "${use_rb}" = "False" || "${rb_root}" != file://* ]]; then
     exit 1
 fi
 
-: ${STAGING_BUILDER_IMAGE?"Staging builder image path not set."}
+: ${TAG?"Staging builder image tag not set."}
+STAGING_BUILDER_IMAGE=gcr.io/gcp-runtimes/go1-builder:${TAG}
 envsubst < test.yaml.in > test.yaml
 
 cd $(dirname $0)

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -15,9 +15,8 @@
 # limitations under the License.
 
 # test.sh deploys the test app and run the integration test on it.
-# usage: test.sh <project_id>
 
-usage() { echo "Usage: $0 <project_id> <builder_image_tag>"; exit 1; }
+usage() { echo "Usage: $0 <project_id> [builder_image_tag]"; exit 1; }
 
 set -e
 

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -17,7 +17,7 @@
 # test.sh deploys the test app and run the integration test on it.
 # usage: test.sh <project_id>
 
-usage() { echo "Usage: $0 <project_id>"; exit 1; }
+usage() { echo "Usage: $0 <project_id> <builder_image_tag>"; exit 1; }
 
 set -e
 
@@ -25,6 +25,13 @@ PROJECT="$1"
 if [[ -z "${PROJECT}" ]]; then
     usage
 fi
+
+TAG="$2"
+if [[ -z "${TAG}" ]]; then
+	TAG="staging"
+fi
+
+export STAGING_BUILDER_IMAGE=gcr.io/gcp-runtimes/go1-builder:${TAG}
 
 # Check if the config file is set to the proper local path
 use_rb="$(gcloud config get-value app/use_runtime_builders)"
@@ -34,8 +41,6 @@ if [[ "${use_rb}" = "False" || "${rb_root}" != file://* ]]; then
     exit 1
 fi
 
-: ${TAG?"Staging builder image tag not set."}
-STAGING_BUILDER_IMAGE=gcr.io/gcp-runtimes/go1-builder:${TAG}
 envsubst < test.yaml.in > test.yaml
 
 cd $(dirname $0)

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -34,9 +34,12 @@ if [[ "${use_rb}" = "False" || "${rb_root}" != file://* ]]; then
     exit 1
 fi
 
+: ${STAGING_BUILDER_IMAGE?"Staging builder image path not set."}
+envsubst < test.yaml.in > test.yaml
+
 cd $(dirname $0)
 export GOPATH=$(pwd -P)
 
 echo "Deploying test app using config in ${rb_root}/runtimes.yaml"
 gcloud beta app deploy -q --project="${PROJECT}" src/app/app.yaml
-gcloud container builds submit --project="${PROJECT}" --config=test.yaml .
+gcloud container builds submit --project="${PROJECT}" --config=go-test.yaml .

--- a/runtime-builder/tests/integration/test.yaml
+++ b/runtime-builder/tests/integration/test.yaml
@@ -1,9 +1,6 @@
 steps:
-- name: gcr.io/gcp-runtimes/integration_test
-  args: [
-    '--no-deploy',
-    '--url', 'https://$PROJECT_ID.appspot.com',
-    '--skip-monitoring-tests',
-    '--skip-standard-logging-tests',
-    '--skip-custom-logging-tests'
-  ]
+- name: 'gcr.io/gcp-runtimes/go1-builder:latest'
+- name: 'gcr.io/cloud-builders/docker:latest'
+  args: ['build', '-t', '', '.']
+images:
+- ''

--- a/runtime-builder/tests/integration/test.yaml
+++ b/runtime-builder/tests/integration/test.yaml
@@ -1,6 +1,0 @@
-steps:
-- name: 'gcr.io/gcp-runtimes/go1-builder:latest'
-- name: 'gcr.io/cloud-builders/docker:latest'
-  args: ['build', '-t', '', '.']
-images:
-- ''

--- a/runtime-builder/tests/integration/test.yaml.in
+++ b/runtime-builder/tests/integration/test.yaml.in
@@ -1,0 +1,6 @@
+steps:
+- name: '${STAGING_BUILDER_IMAGE}'
+- name: 'gcr.io/cloud-builders/docker:latest'
+  args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
+images:
+- '$_OUTPUT_IMAGE'


### PR DESCRIPTION
This updates the directory structure of the golang integration testing sample application to reflect what's expected in the latest changes to the framework (see https://github.com/GoogleCloudPlatform/runtimes-common/pull/224). The test driver will now look for a `test.yaml.in` (the same way it looks for `Dockerfile.in` when testing runtime base images), substitute in the `STAGING_BUILDER_IMAGE` environment variable into the builder yaml, and use this to deploy the application.

@cybrcodr @shantuo 