### PR TITLE
Add hello world application for flex deploy check

### DIFF
--- a/runtime-builder/tests/deploy_check/app.yaml
+++ b/runtime-builder/tests/deploy_check/app.yaml
@@ -1,0 +1,2 @@
+runtime: go
+env: flex

--- a/runtime-builder/tests/deploy_check/helloworld.go
+++ b/runtime-builder/tests/deploy_check/helloworld.go
@@ -1,0 +1,31 @@
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// Sample helloworld is a basic App Engine flexible app.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", handle)
+	http.HandleFunc("/_ah/health", healthCheckHandler)
+	log.Print("Listening on port 8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	fmt.Fprint(w, "Hello world!")
+}
+
+func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "ok")
+}


### PR DESCRIPTION
This is taken from https://github.com/GoogleCloudPlatform/golang-samples, and is used to ensure basic flex deploys work as intended.

@cybrcodr @shantuo 