### PR TITLE
runtime-builder/tests/integration: fix use of test.yaml.in

### DIFF
--- a/runtime-builder/tests/README.md
+++ b/runtime-builder/tests/README.md
@@ -3,22 +3,45 @@
 This directory defines tests for the Go runtime builder image.
 
 ## Structure Test
-The structure test is invoked in the cloud build steps after the builder image is built. It checks the environment setup and the existence of specific files in the image. Failing the structure test will also fail the whole submission.
-See the structure tests [README](https://github.com/GoogleCloudPlatform/runtimes-common/blob/master/structure_tests/README.md)
+The structure test is invoked in the cloud build steps after the builder image
+is built. It checks the environment setup and the existence of specific files
+in the image. Failing the structure test will also fail the whole submission.
+See the structure tests
+[README](https://github.com/GoogleCloudPlatform/runtimes-common/blob/master/structure_tests/README.md)
 for information on how to write tests.
 
 ## Integration Test
-The \/integration directory contains a test web application for performing an end to end test.
-Refer to integration test framework [README](https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/integration_tests) for the design and requirements. The directory serves as a GOPATH. It also includes all the dependencies for it to be used by the test container. A test.yaml.in is provided as the templated cloudbuild.yaml for deploying the app: the ${STAGING_IMAGE} environment variable will contain the path to the go1-builder staging image to use (this variable must be set). Every newly built image will have the "staging" tag.
+The integration directory contains a test web application for performing an end to end test.
+Refer to integration test framework
+[README](https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/integration_tests)
+for the design and requirements.
+
+The directory serves as a hermetic GOPATH. It includes all the dependencies for
+it to be used by the test container. Use the go-get.sh script to update
+dependencies if necessary.
+
+The test.sh script executes the end-to-end test with the following steps:
+* Generate a test.yaml file for use as the cloudbuild.yaml referenced in runtimes.yaml.
+* Deploy the test app.
+* Executes the integration test defined in go-test.yaml through Container Builder.
 
 To perform the test:
-* Manually run a container build of the go1-builder image. Skip this step if you already have an existing image in GCR that you want to test.
+* Manually run a container build of the go1-builder image. Skip this step if
+  you already have an existing image in GCR that you want to test.
 * Set `gcloud config set app/use_runtime_builders true`
-* Set `gcloud config set app/runtime_builders_root` to the integration/ directory.
-* Run test.sh \<project_id>. This will use the generated test.yaml to build and deploy the test app. It will also invoke the test driver to perform the test suite to verify that it is working.
-* Optionally pass in the builder image tag name as the second parameter to use a different builder image (default tag is "staging").
+* Set `gcloud config set app/runtime_builders_root` to the integration
+  directory.
+* Run test.sh.
+
+Usage:
+```
+test.sh <project_id> [builder_image_tag]
+```
+* `builder_image_tag` is optional. Default value is 'staging' because that tag
+  is applied during the build process.
 
 ### Caveat
-There is an issue with the authentication of the test framework.
-The test robot of the cloud container build system doesn't have the correct authentication to read the monitoring metrics or log entries.
-Affected tests are skipped until the fix made.
+There is an issue with the authentication of the test framework.  The test
+robot of the cloud container build system doesn't have the correct
+authentication to read the monitoring metrics or log entries.
+Affected tests are skipped until the issue is fixed.

--- a/runtime-builder/tests/README.md
+++ b/runtime-builder/tests/README.md
@@ -35,9 +35,9 @@ To perform the test:
 
 Usage:
 ```
-test.sh <project_id> [builder_image_tag]
+test.sh <project_id> [builder_tag]
 ```
-* `builder_image_tag` is optional. Default value is 'staging' because that tag
+* `builder_tag` is optional. Default value is 'staging' because that tag
   is applied during the build process.
 
 ### Caveat

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -16,7 +16,7 @@
 
 # test.sh deploys the test app and run the integration test on it.
 
-usage() { echo "Usage: $0 <project_id> [builder_image_tag | builder_image_url]"; exit 1; }
+usage() { echo "Usage: $0 <project_id> [builder_image_tag]"; exit 1; }
 
 set -e
 
@@ -25,16 +25,13 @@ if [[ -z "${PROJECT}" ]]; then
     usage
 fi
 
-if [[ "$2" =~ ^gcr.io/ ]]; then
-    export STAGING_BUILDER_IMAGE="$2"
-else
-    TAG="${2:-staging}"
-    export STAGING_BUILDER_IMAGE="gcr.io/gcp-runtimes/go1-builder:${TAG}"
-fi
+# Use staging tag if builder_image_tag argument is not set since latest build
+# will always be tagged with 'staging'.
+TAG="${2:-staging}"
+STAGING_BUILDER_IMAGE="gcr.io/${PROJECT}/go1-builder:${TAG}"
+echo "Builder image: ${STAGING_BUILDER_IMAGE}"
 
-export OUTPUT_IMAGE="\$_OUTPUT_IMAGE"
-
-# Check if the config file is set to the proper local path
+# Make sure gcloud is configured to use the local directory.
 use_rb="$(gcloud config get-value app/use_runtime_builders)"
 rb_root="$(gcloud config get-value app/runtime_builders_root)"
 if [[ "${use_rb}" = "False" || "${rb_root}" != file://* ]]; then
@@ -42,7 +39,9 @@ if [[ "${use_rb}" = "False" || "${rb_root}" != file://* ]]; then
     exit 1
 fi
 
-envsubst < test.yaml.in > test.yaml
+# Generate test.yaml from test.yaml.in by substituting STAGING_BUILDER_IMAGE variable.
+# test.yaml is referenced in runtimes.yaml as the cloudbuild.yaml file.
+sed "s|\${STAGING_BUILDER_IMAGE}|${STAGING_BUILDER_IMAGE}|" test.yaml.in > test.yaml
 
 cd $(dirname $0)
 export GOPATH=$(pwd -P)

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -16,7 +16,7 @@
 
 # test.sh deploys the test app and run the integration test on it.
 
-usage() { echo "Usage: $0 <project_id> [builder_image_tag]"; exit 1; }
+usage() { echo "Usage: $0 <project_id> [builder_tag]"; exit 1; }
 
 set -e
 
@@ -25,7 +25,7 @@ if [[ -z "${PROJECT}" ]]; then
     usage
 fi
 
-# Use staging tag if builder_image_tag argument is not set since latest build
+# Use staging tag if builder_tag argument is not set since latest build
 # will always be tagged with 'staging'.
 TAG="${2:-staging}"
 STAGING_BUILDER_IMAGE="gcr.io/${PROJECT}/go1-builder:${TAG}"

--- a/runtime-builder/tests/integration/test.yaml.in
+++ b/runtime-builder/tests/integration/test.yaml.in
@@ -1,6 +1,6 @@
 steps:
 - name: '${STAGING_BUILDER_IMAGE}'
 - name: 'gcr.io/cloud-builders/docker:latest'
-  args: ['build', '-t', '${OUTPUT_IMAGE}', '.']
+  args: ['build', '-t', '${_OUTPUT_IMAGE}', '.']
 images:
-- '${OUTPUT_IMAGE}'
+- '${_OUTPUT_IMAGE}'


### PR DESCRIPTION
test.yaml.in needs to retain ${_OUTPUT_IMAGE} variable for use by
integration framework.

Updated test.sh also to not rely on envsubst since that does not work on
Macs.

Updated documentation.