### PR TITLE
runtime-builder/tests: update test.sh parameter

### DIFF
--- a/runtime-builder/tests/README.md
+++ b/runtime-builder/tests/README.md
@@ -35,10 +35,11 @@ To perform the test:
 
 Usage:
 ```
-test.sh <project_id> [builder_tag]
+test.sh <project_id> [builder_image_url]
 ```
-* `builder_tag` is optional. Default value is 'staging' because that tag
-  is applied during the build process.
+* `builder_image_url` is optional. Default value is
+  'gcr.io/${project_id}/go1-builder:staging' because the 'staging' tag is
+  applied during the build process.
 
 ### Caveat
 There is an issue with the authentication of the test framework.  The test

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -16,7 +16,7 @@
 
 # test.sh deploys the test app and run the integration test on it.
 
-usage() { echo "Usage: $0 <project_id> [builder_tag]"; exit 1; }
+usage() { echo "Usage: $0 <project_id> <builder_image_url>"; exit 1; }
 
 set -e
 
@@ -25,10 +25,10 @@ if [[ -z "${PROJECT}" ]]; then
     usage
 fi
 
-# Use staging tag if builder_tag argument is not set since latest build
-# will always be tagged with 'staging'.
-TAG="${2:-staging}"
-STAGING_BUILDER_IMAGE="gcr.io/${PROJECT}/go1-builder:${TAG}"
+STAGING_BUILDER_IMAGE="$2"
+if [[ -z "${STAGING_BUILDER_IMAGE}" ]]; then
+    usage
+fi
 echo "Builder image: ${STAGING_BUILDER_IMAGE}"
 
 # Make sure gcloud is configured to use the local directory.

--- a/runtime-builder/tests/integration/test.sh
+++ b/runtime-builder/tests/integration/test.sh
@@ -16,7 +16,7 @@
 
 # test.sh deploys the test app and run the integration test on it.
 
-usage() { echo "Usage: $0 <project_id> <builder_image_url>"; exit 1; }
+usage() { echo "Usage: $0 <project_id> [builder_image_url]"; exit 1; }
 
 set -e
 
@@ -25,10 +25,9 @@ if [[ -z "${PROJECT}" ]]; then
     usage
 fi
 
-STAGING_BUILDER_IMAGE="$2"
-if [[ -z "${STAGING_BUILDER_IMAGE}" ]]; then
-    usage
-fi
+# If builder_image_url parameter is not set, default to project's go1-builder
+# staging image.
+STAGING_BUILDER_IMAGE=${2:-gcr.io/${PROJECT}/go1-builder:staging}
 echo "Builder image: ${STAGING_BUILDER_IMAGE}"
 
 # Make sure gcloud is configured to use the local directory.


### PR DESCRIPTION
Update test.sh parameter to take in builder image URL instead of tag.

I find the need to test images in gcp-runtimes as well as ones under my
project or other projects.