### PR TITLE
runtime-builder: add /usr/share/zoneinfo into app image.

### DIFF
--- a/runtime-builder/go-build.sh
+++ b/runtime-builder/go-build.sh
@@ -42,6 +42,9 @@ go build -o "${workspace}"/bin/app -tags appenginevm
 cd "${workspace}"
 mv "${staging}" "${workspace}"/app
 
+# Copy zoneinfo directory into workspace in order to be placed into final image.
+cp -p -R /usr/share/zoneinfo "${workspace}"/zoneinfo
+
 # Generate application Dockerfile.
 cat > Dockerfile <<EOF
 FROM gcr.io/distroless/base@${BASE_DIGEST}
@@ -51,6 +54,7 @@ LABEL go_version="${GO_VERSION}"
 
 COPY bin/ /usr/local/bin/
 COPY app/ /app/
+COPY zoneinfo/ /usr/share/zoneinfo/
 
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/app"]

--- a/runtime-builder/tests/integration/src/app/server.go
+++ b/runtime-builder/tests/integration/src/app/server.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/errors"
@@ -77,6 +78,7 @@ func main() {
 	http.HandleFunc("/", mainHandler)
 	http.HandleFunc("/_ah/health", healthCheckHandler)
 	http.HandleFunc("/version", versionHandler)
+	http.Handle("/tzinfo", appHandler(tzinfoHandler))
 	http.Handle("/lookup_host", appHandler(lookupHostHandler))
 	http.Handle("/logging_custom", appHandler(customLoggingHandler))
 	http.Handle("/monitoring", appHandler(monitoringHandler))
@@ -100,6 +102,15 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 func versionHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Go version=%s\nGOARCH=%s\nGOOS=%s\n", runtime.Version(), runtime.GOARCH, runtime.GOOS)
+}
+
+func tzinfoHandler(w http.ResponseWriter, r *http.Request) error {
+	loc, err := time.LoadLocation("US/Pacific")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(w, loc.String())
+	return nil
 }
 
 func lookupHostHandler(w http.ResponseWriter, r *http.Request) error {
@@ -214,6 +225,10 @@ func customHandler(w http.ResponseWriter, r *http.Request) error {
 		{
 			Name: "Lookup Host",
 			Path: "/lookup_host",
+		},
+		{
+			Name: "TimeZone",
+			Path: "/tzinfo",
 		},
 	}
 	return json.NewEncoder(w).Encode(tests)


### PR DESCRIPTION
Add /usr/share/zoneinfo into app image and add custom test to make sure time.LoadLocation works.