### PR TITLE
runtime-builder: update go-build.sh to use _gopath/main-package-path

### DIFF
--- a/runtime-builder/go-build.sh
+++ b/runtime-builder/go-build.sh
@@ -39,7 +39,7 @@ export GOPATH="${workspace}"/_gopath
 # to GOPATH/src by moving files over.
 mainpath=""
 if [[ -f "${GOPATH}/main-package-path" ]]; then
-  mainpkg=$(cat ${GOPATH}/main-package-path)
+  mainpkg=$(cat "${GOPATH}/main-package-path")
   if [[ "$mainpkg" != "" ]]; then
     mainpath="${GOPATH}/src/${mainpkg}"
     mkdir -p "${mainpath}"


### PR DESCRIPTION
go-app-stager will generate _gopath/main-package-path containing the
relative path of package main from GOPATH if GOPATH is set and main
package files are under GOPATH.

Update go-build.sh to utilize this info in order to reconstruct the main
package directory and build from there.  This should fix issues with
vendor and internal packages along the path that main should have access
to.