### PR TITLE
default to GKE if GAE env vars not found, and remove newlines

### DIFF
--- a/runtime-builder/tests/integration/src/app/server.go
+++ b/runtime-builder/tests/integration/src/app/server.go
@@ -263,9 +263,9 @@ func pingFooHandler(w http.ResponseWriter, r *http.Request) error {
 
 func environmentHandler(w http.ResponseWriter, r *http.Request) error {
 	if os.Getenv(envFlex) != "" || os.Getenv(envVM) != "" {
-		fmt.Fprintln(w, "GAE")
+		fmt.Fprint(w, "GAE")
 	} else {
-		fmt.Fprintln(w, "GKE")
+		fmt.Fprint(w, "GKE")
 	}
 	return nil
 }

--- a/runtime-builder/tests/integration/src/app/server.go
+++ b/runtime-builder/tests/integration/src/app/server.go
@@ -264,6 +264,8 @@ func pingFooHandler(w http.ResponseWriter, r *http.Request) error {
 func environmentHandler(w http.ResponseWriter, r *http.Request) error {
 	if os.Getenv(envFlex) != "" || os.Getenv(envVM) != "" {
 		fmt.Fprintln(w, "GAE")
+	} else {
+		fmt.Fprintln(w, "GKE")
 	}
 	return nil
 }


### PR DESCRIPTION
This should fix the integration tests.

cc @shantuo 