### PR TITLE
Use kaniko to run builds for go 1.11

### DIFF
--- a/runtime-builder/go-1.11.yaml
+++ b/runtime-builder/go-1.11.yaml
@@ -1,6 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.11'
-- name: 'gcr.io/cloud-builders/docker:latest'
-  args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
-images:
-- '$_OUTPUT_IMAGE'
+- name: 'gcr.io/kaniko-project/executor:v0.4.0@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
+  args: ['--destination=$_OUTPUT_IMAGE']

--- a/runtime-builder/go-1.11.yaml
+++ b/runtime-builder/go-1.11.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.11'
-- name: 'gcr.io/kaniko-project/executor:v0.4.0@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
+- name: 'gcr.io/kaniko-project/executor@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
   args: ['--destination=$_OUTPUT_IMAGE']


### PR DESCRIPTION
[`kaniko`](https://github.com/GoogleContainerTools/kaniko) builds container images from a Dockerfile, and enables future improvements to speed up builds by using the image registry as a layer cache (https://github.com/GoogleContainerTools/kaniko/issues/300)

The kaniko builder image is referenced by digest to avoid potential bad kaniko releases, and the tag is included so humans reading the config know what kaniko version is used.