### PR TITLE
Specify kaniko builder by tag

### DIFF
--- a/runtime-builder/go-1.11.yaml
+++ b/runtime-builder/go-1.11.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.11'
-- name: 'gcr.io/kaniko-project/executor@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af'
+- name: 'gcr.io/kaniko-project/executor:v0.4.0'
   args: ['--destination=$_OUTPUT_IMAGE']


### PR DESCRIPTION
App Engine already resolves tags to digests when these configs are pushed, so hard-coding the digest was unnecessary and loses useful version information.