### PR TITLE
Switch from debian to ubuntu base in go builder image

### DIFF
--- a/runtime-builder/Dockerfile
+++ b/runtime-builder/Dockerfile
@@ -20,7 +20,7 @@
 # When this builder image is executed, it expects the application source files
 # to be mounted at the current work directory.
 
-FROM gcr.io/google-appengine/debian9:latest
+FROM gcr.io/gcp-runtimes/ubuntu_16_0_4:latest
 
 ARG go_version
 ARG base_digest

--- a/runtime-builder/tests/structure/test_config.yaml
+++ b/runtime-builder/tests/structure/test_config.yaml
@@ -11,5 +11,5 @@ fileExistenceTests:
   permissions: '-rwxr-xr-x'
 
 licenseTests:
-- debian: true
+- debian: false
   files: []


### PR DESCRIPTION
we've switched nearly all of our other maintained language runtime images over to using ubuntu as a base already. this PR will bring the go builder image more in line with the rest of our language images.