### PR TITLE
Adding version control tools as a fall back for go mod proxy

### DIFF
--- a/runtime-builder/Dockerfile
+++ b/runtime-builder/Dockerfile
@@ -29,7 +29,7 @@ ENV GO_VERSION ${go_version}
 ENV BASE_DIGEST ${base_digest}
 ENV BUILD_TAG ${build_tag}
 
-RUN apt-get update -yq && apt-get upgrade -yq
+RUN apt-get update -yq && apt-get upgrade -yq && apt-get install -y bzr git git-core mercurial subversion
 
 # Copy checksum for use in validation.
 COPY checksums/go${GO_VERSION}.sha256 /tmp/


### PR DESCRIPTION
We're adding version control tools for all go builders so that when the go module proxy fails, it can use git or other tools as a fallback.