### PR TITLE
Upgrade all builders to Kaniko v1.3.0

### DIFF
--- a/runtime-builder/go-1.10.yaml
+++ b/runtime-builder/go-1.10.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.10'
-- name: 'gcr.io/kaniko-project/executor:v0.6.0'
+- name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']

--- a/runtime-builder/go-1.11.yaml
+++ b/runtime-builder/go-1.11.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.11'
-- name: 'gcr.io/kaniko-project/executor:v0.6.0'
+- name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']

--- a/runtime-builder/go-1.12.yaml
+++ b/runtime-builder/go-1.12.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.12'
-- name: 'gcr.io/kaniko-project/executor:v0.6.0'
+- name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']

--- a/runtime-builder/go-1.13.yaml
+++ b/runtime-builder/go-1.13.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.13'
-- name: 'gcr.io/kaniko-project/executor:v0.6.0'
+- name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']

--- a/runtime-builder/go-1.14.yaml
+++ b/runtime-builder/go-1.14.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.14'
-- name: 'gcr.io/kaniko-project/executor:v0.6.0'
+- name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']

--- a/runtime-builder/go-1.15.yaml
+++ b/runtime-builder/go-1.15.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.15'
-- name: 'gcr.io/kaniko-project/executor:v0.6.0'
+- name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']


### PR DESCRIPTION
This addresses failures reported in https://github.com/GoogleCloudPlatform/golang-samples/issues/1799, later reported to kaniko in https://github.com/GoogleContainerTools/kaniko/issues/1465 by using a newer version of Kaniko that supports multi-arch base images like distroless.

cc @jonjohnsonjr for spotting that these were using such old versions of Kaniko.