### PR TITLE
Remove log streaming

### DIFF
--- a/runtime-builder/cloudbuild.yaml
+++ b/runtime-builder/cloudbuild.yaml
@@ -18,3 +18,5 @@ steps:
   ]
 
 images: ['gcr.io/${_PROJECT_ID}/go1-builder:${_BUILD_TAG}']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/go-1.10.yaml
+++ b/runtime-builder/go-1.10.yaml
@@ -2,3 +2,5 @@ steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.10'
 - name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/go-1.11.yaml
+++ b/runtime-builder/go-1.11.yaml
@@ -2,3 +2,5 @@ steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.11'
 - name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/go-1.12.yaml
+++ b/runtime-builder/go-1.12.yaml
@@ -2,3 +2,5 @@ steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.12'
 - name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/go-1.13.yaml
+++ b/runtime-builder/go-1.13.yaml
@@ -2,3 +2,5 @@ steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.13'
 - name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/go-1.14.yaml
+++ b/runtime-builder/go-1.14.yaml
@@ -2,3 +2,5 @@ steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.14'
 - name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/go-1.15.yaml
+++ b/runtime-builder/go-1.15.yaml
@@ -2,3 +2,5 @@ steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.15'
 - name: 'gcr.io/kaniko-project/executor:v1.3.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/go-1.9.yaml
+++ b/runtime-builder/go-1.9.yaml
@@ -2,3 +2,5 @@ steps:
 - name: 'gcr.io/gcp-runtimes/go1-builder:1.9'
 - name: 'gcr.io/kaniko-project/executor:v0.6.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/tests/integration/go-test.yaml
+++ b/runtime-builder/tests/integration/go-test.yaml
@@ -6,3 +6,5 @@ steps:
     '--skip-standard-logging-tests',
     '--skip-custom-logging-tests'
   ]
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/runtime-builder/tests/integration/test.yaml.in
+++ b/runtime-builder/tests/integration/test.yaml.in
@@ -4,3 +4,5 @@ steps:
   args: ['build', '-t', '${_OUTPUT_IMAGE}', '.']
 images:
 - '${_OUTPUT_IMAGE}'
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Disable log streaming. It should still be viewable in Cloud Build UI.

Reasons:
- The cloud build service account no longer has the Viewer role, because it's disallowed.
- Apparently, Viewer or Owner is required to stream logs. So when the request to stream logs is sent, the Kokoro job fails even though the cloud build runs fine.
- If we disable log streaming, this should unblock the Kokoro job.